### PR TITLE
Add instructions to register the new provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Run the omnikassa migrations
 Update Omnikassa settings (or leave them as they are for testing)
 
 	http://0.0.0.0:3000/admin/omnikassa_settings/edit
+	
+Register the provider in your settings. In `config/initializers/spree.rb`:
+
+```ruby
+Rails.application.config.spree.payment_methods << Spree::BillingIntegration::Omnikassa
+```
 
 Create a payment method with `Spree::BillingIntegration::Omnikassa` as provider.
 


### PR DESCRIPTION
In spree 2.1.4 (and possible other versions too) the providers must be added in the config.
