### PR TITLE
Bug fix for use of checkout -> solves issue of error with checkout after...

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -16,6 +16,8 @@ Spree::CheckoutController.class_eval do
     end
 
     def is_omnikassa_payment?
-      @order.payment_method.class == Spree::BillingIntegration::Omnikassa
+      @order.payments.all? do |payment|
+        payment.payment_method.class == Spree::BillingIntegration::Omnikassa
+      end
     end
 end

--- a/app/overrides/add_omnikassa_payment_method_to_order_details.rb
+++ b/app/overrides/add_omnikassa_payment_method_to_order_details.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(:virtual_path => "spree/shared/_order_details",
                      :name => "add_omnikassa_payment_method_method_to_order_details",
                      :insert_bottom => '.payment-info',
-                     :text => '<% if @order.payment_method.class == Spree::BillingIntegration::Omnikassa %>
-                                  <%= @order.payment_method.name %>
-                               <% end %>')
+                     :text => '<% @order.payments.each do |payment| %>
+                                <%= payment.payment_method.name %>
+                              <% end %>')


### PR DESCRIPTION
... install omnikassa. Order.payment_method did not exist

Solves issue on checkout after install of Omnikassa, where an exception was raised because Spree::Order.payment_method could not be found.

Checkout while choosing "check" is still broken, because Spree::CheckoutController.completion_route's super cannot be called.
