### PR TITLE
added customer language setting

### DIFF
--- a/app/controllers/spree/admin/omnikassa_settings_controller.rb
+++ b/app/controllers/spree/admin/omnikassa_settings_controller.rb
@@ -6,6 +6,7 @@ module Spree
         @preferences_omnikassa = [:omnikassa_merchant_id,
                                   :omnikassa_secret_key,
                                   :omnikassa_key_version,
+                                  :omnikassa_customer_language,
                                   :omnikassa_transaction_reference_prefix,
                                   :omnikassa_url]
 

--- a/app/controllers/spree/omnikassa_controller.rb
+++ b/app/controllers/spree/omnikassa_controller.rb
@@ -39,6 +39,7 @@ module Spree
           :omnikassa_transaction_reference => data[:transactionReference],
           :omnikassa_authorisation_id => data[:authorisationId],
           :omnikassa_key_version => data[:keyVersion],
+          :omnikassa_customer_language => data[:customerLanguage],
           :omnikassa_payment_mean_brand => data[:paymentMeanBrand],
           :omnikassa_payment_mean_type => data[:paymentMeanType],
           :omnikassa_response_code => data[:responseCode],
@@ -118,7 +119,8 @@ module Spree
           :normalReturnUrl => normal_return_url,
           :automaticResponseUrl => automatic_response_url,
           :transactionReference => transaction_reference,
-          :keyVersion => key_version, }
+          :keyVersion => key_version,
+          :customerLanguage => customer_language, }
       end
 
       def normal_return_url
@@ -139,6 +141,10 @@ module Spree
 
       def key_version
         Spree::Config[:omnikassa_key_version]
+      end
+
+      def customer_language
+        Spree::Config[:omnikassa_customer_language]
       end
 
       # SCCS

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -2,6 +2,7 @@ Spree::AppConfiguration.class_eval do
   preference :omnikassa_url, :string, :default => 'https://payment-webinit.simu.omnikassa.rabobank.nl/paymentServlet'
   preference :omnikassa_merchant_id, :string, :default => '002020000000001'
   preference :omnikassa_secret_key, :string, :default => '002020000000001_KEY1'
-  preference :omnikassa_key_version, :string, :default => '1' 
+  preference :omnikassa_key_version, :string, :default => '1'
   preference :omnikassa_transaction_reference_prefix, :string, :default => 'PREFIX'
+  preference :omnikassa_customer_language, :string, :default => 'NL'
 end

--- a/app/views/spree/admin/payments/source_views/_omnikassa.html.erb
+++ b/app/views/spree/admin/payments/source_views/_omnikassa.html.erb
@@ -13,6 +13,7 @@
                 <li><strong><%= t(:transaction_date_time) %>:</strong>  <%= omnikassa_payment.omnikassa_transaction_date_time %></li>
                 <li><strong><%= t(:transaction_reference) %>:</strong>  <%= omnikassa_payment.omnikassa_transaction_reference %></li>
                 <li><strong><%= t(:authorisation_id) %>:</strong>  <%= omnikassa_payment.omnikassa_authorisation_id %></li>
+                <li><strong><%= t(:customer_language) %>:</strong>  <%= omnikassa_payment.omnikassa_customer_language %></li>
                 <li><strong><%= t(:key_version) %>:</strong>  <%= omnikassa_payment.omnikassa_key_version %></li>
                 <li><strong><%= t(:payment_mean_brand) %>:</strong>  <%= omnikassa_payment.omnikassa_payment_mean_brand %></li>
                 <li><strong><%= t(:payment_mean_type) %>:</strong>  <%= omnikassa_payment.omnikassa_payment_mean_type %></li>

--- a/db/migrate/20161017102233_add_customer_language_to_omnikassa_payments.rb
+++ b/db/migrate/20161017102233_add_customer_language_to_omnikassa_payments.rb
@@ -1,0 +1,5 @@
+class AddCustomerLanguageToOmnikassaPayments < ActiveRecord::Migration
+  def change
+    add_column :spree_omnikassa_payments, :omnikassa_customer_language, :string
+  end
+end

--- a/lib/spree/omnikassa_configuration.rb
+++ b/lib/spree/omnikassa_configuration.rb
@@ -1,6 +1,7 @@
 class Spree::OmnikassaConfiguration < Spree::Preferences::Configuration
   preference :omnikassa_merchant_id, :string, :default => '002020000000001'
   preference :omnikassa_secret_key, :string, :default => '002020000000001_KEY1'
-  preference :omnikassa_key_version, :string, :default => '1' 
+  preference :omnikassa_key_version, :string, :default => '1'
   preference :omnikassa_transaction_reference_prefix, :string, :default => 'PREFIX'
+  preference :omnikassa_customer_language, :string, :default => 'NL'
 end


### PR DESCRIPTION
Sometimes Omnikassa language is english.
By default Omnikassa sets the language to the browser language.
Now you can set it to whatever you want.
